### PR TITLE
Fix ec2-instance command

### DIFF
--- a/zsh/utils/ec2-ssh
+++ b/zsh/utils/ec2-ssh
@@ -96,7 +96,7 @@ function ec2-instances() {
       --query 'Reservations[*].Instances[*].[Tags[?Key==`Name`].Value[],PublicIpAddress,PrivateIpAddress]' \
       --output json \
       --profile $EC2_PROFILE | \
-      jq -r 'sort_by(.[][]) | reverse | .[][] | [ (.[0][] // "null"), .[1], .[2] ] | @sh'
+      jq -r -c 'sort_by(.[][]) | reverse | .[][] | [ (.[0][] // "null"), .[1], .[2] ] | join(" ")'
 }
 
 # ec2-scp


### PR DESCRIPTION
Current command's output is whitespace-separated strings, which makes the following commands such as `ec2-ssh` and etc. not work. Adding these jq options will remove the quotes and make it properly work.

**CURRENT**

```
$ ec2-ssh

> 'foo-instance' 'xx.xx.xx.x' 'yyy.yy.yy.yyy'
> 'bar-instance' 'xx.xx.xx.x' 'yyy.yy.yy.yyy'

=> ssh: Could not resolve hostname 'xx.xx.xx.x': nodename nor servname provided, or not known
```

**FIXED**

```
$ ec2-ssh

> foo-instance xx.xx.xx.x yyy.yy.yy.yyy
> bar-instance xx.xx.xx.x yyy.yy.yy.yyy

=> ssh login succeeds
```
